### PR TITLE
Make masterfile installable with pip

### DIFF
--- a/Example.ipynb
+++ b/Example.ipynb
@@ -8,30 +8,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## If not in your pythonpath, add these two lines"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from sys import path\n",
-    "path.append('/Absolute/Path/To/The/Code/masterfile/')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Now import"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
@@ -963,7 +939,8 @@
    "source": [
     "import astropy.units as u\n",
     "from astropy.modeling.blackbody import blackbody_lambda\n",
-    "from numpy import isfinite, where"
+    "from numpy import isfinite, where\n",
+    "import matplotlib.pyplot as plt"
    ]
   },
   {

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Here is a scheme of the concept:
 ![Concept_scheme](schema.png)
 
 Explanations:
-1. The [Confirmed Planet Table](https://exoplanetarchive.ipac.caltech.edu/docs/API_exoplanet_columns.html) is used to fill the masterfile. 
+1. The [Confirmed Planet Table](https://exoplanetarchive.ipac.caltech.edu/docs/API_exoplanet_columns.html) is used to fill the masterfile.
 2. Then, the [Extended Planet Table](https://exoplanetarchive.ipac.caltech.edu/docs/API_exomultpars_columns.html) is used to fill the missing values. The references are sorted according to the error on the orbital period (this could be changed). All the values from a particular reference are used to keep a minimum of consistency.
 
 The resulting file is called _masterfile.ecsv_ and can be used directly. It is also possible to complement this _masterfile.ecsv_ with:
@@ -35,15 +35,23 @@ To do so, simply use the following code:
 from masterfile.archive import MasterFile
 data = MasterFile.load()
 ```
-`data`is an instance of MasterFile which is inheriting from [astropy.table.Table](https://docs.astropy.org/en/stable/table/access_table.html) class (so it has the same behaviour).
+`data` is an instance of MasterFile which is inheriting from [astropy.table.Table](https://docs.astropy.org/en/stable/table/access_table.html) class (so it has the same behaviour).
 
-Setup
+Installation
 -----
-Simply clone `masterfile`. One simple way to do it is to run the following line in a terminal (you need to be in the directory where you want to copy `masterfile`).
+To install `masterfile`, simply clone the Github repository and install the project locally with pip. One simple way to do it is to run the following line in a terminal (you need to be in the directory where you want to copy `masterfile`).
 ```unix
 git clone https://github.com/AntoineDarveau/masterfile.git
+cd masterfile
+python -m pip install -U pip
+python -m pip install -U .
 ```
-Then, there are many ways to refer to the code, but one could be to add the ` '/path/to/repository/masterfile/' ` to your `PYTHONPATH`. See this [link](https://stackoverflow.com/questions/3402168/permanently-add-a-directory-to-pythonpath) for more information on how to do that. This will ensure that you can import `masterfile` from anywhere in your computer. Another way is to add ` from sys import path; path.append('/path/to/repository/masterfile/')) ` at the beggining of each code and then you will be able to import `masterfile`
+
+You can also install directly from github using `python3 -m pip install -U git+https://github.com/AntoineDarveau/masterfile.git#egg=masterfile`.
+
+To install `masterfile` for development, it is recommended to use an isolated environment with a tool like conda, virtualenv or venv. Inside your environment, you can install following the steps above, but replacing `python -m pip install -U .` by `python -m pip install -U -e ".[dev]"`. This will install `masterfile` in editable mode (`-e`) and it will install the development dependencies.
+
+You can then use `masterfile` with `import masterfile`. See the notebook for examples.
 
 Customize
 ---------

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ python -m pip install -U pip
 python -m pip install -U .
 ```
 
-You can also install directly from github using `python3 -m pip install -U git+https://github.com/AntoineDarveau/masterfile.git#egg=masterfile`.
+You can also install directly from github using `python3 -m pip install -U "git+https://github.com/AntoineDarveau/masterfile.git#egg=masterfile"`.
 
 To install `masterfile` for development, it is recommended to use an isolated environment with a tool like conda, virtualenv or venv. Inside your environment, you can install following the steps above, but replacing `python -m pip install -U .` by `python -m pip install -U -e ".[dev]"`. This will install `masterfile` in editable mode (`-e`) and it will install the development dependencies.
 

--- a/masterfile/__init__.py
+++ b/masterfile/__init__.py
@@ -1,0 +1,5 @@
+from pkg_resources import get_distribution, DistributionNotFound
+try:
+    __version__ = get_distribution(__name__).version  # get version from setup
+except DistributionNotFound:
+    pass  # package is not installed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "setuptools_scm"]
+build-backend = 'setuptools.build_meta'

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,3 +23,4 @@ dev =
     ipython
     jupyter
     astroplan
+    matplotlib

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,25 @@
+[metadata]
+name = masterfile
+description = A complete exoplanet archive table.
+long_description = file: README.md
+long_description_content_type = text/markdown
+author = Antoine Darveau-Bernier
+author_email = adb@astro.umontreal.ca
+url = https://github.com/AntoineDarveau/masterfile
+license = MIT License
+
+[options]
+zip_safe = False
+packages = find:
+install_requires =
+    numpy
+    astropy
+    requests
+    pyyaml
+
+
+[options.extras_require]
+dev =
+    ipython
+    jupyter
+    astroplan

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ description = A complete exoplanet archive table.
 long_description = file: README.md
 long_description_content_type = text/markdown
 author = Antoine Darveau-Bernier
-author_email = adb@astro.umontreal.ca
+author_email = antoine.darveau@gmail.com
 url = https://github.com/AntoineDarveau/masterfile
 license = MIT License
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,4 @@
+from setuptools import setup
+
+# Use scm for version
+setup(use_scm_version=True)


### PR DESCRIPTION
This PR adds support to install `masterfile` with pip. I added the required setup files and I updated the README as well as the exemple. This should remove the need to manually add masterfile to the PYTHONPATH in most use cases and make it easier to use `masterfile` as a dependency in other projects.